### PR TITLE
Preload drum samples and warm up humanize model

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,11 +6,13 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTheme } from './hooks/useTheme'
 import { useAudio } from './hooks/useAudio'
 import { useHumanize } from './hooks/useHumanize'
+import { useSamplePreload } from './hooks/useSamplePreload'
 import { rescaleOffsets } from './utils/grooveConvert'
 import { HUMANIZE_STYLE } from './data/humanizeStyle'
 import Sequencer from './components/Sequencer'
 import Controls from './components/Controls'
 import Setup from './components/Setup'
+import LoadingScreen from './components/LoadingScreen'
 import ShareModal from './components/ShareModal'
 import Help from './components/Help'
 import { IconSprite, Icon } from './components/Icons'
@@ -33,8 +35,9 @@ const HUMANIZE_IDLE_MS = 5000;
 
 function App() {
   const [theme, , toggleTheme] = useTheme();
+  const { ready: assetsReady, progress: assetsProgress } = useSamplePreload();
   const { isPlaying, currentStep, activeKit, togglePlay, setBpm, updateGrid, setStep, playNote, setPerfLayer, setHumanizeEnabled, setHumanizeOptions } = useAudio();
-  const { phase: humanizePhase, compute: computeHumanize, reset: resetHumanizePhase } = useHumanize();
+  const { phase: humanizePhase, compute: computeHumanize, reset: resetHumanizePhase, warmup: warmupModel, modelPhase, modelProgress } = useHumanize();
   // Humanize is a plain on/off toggle. `humanizeOn` = the user's intent (engine
   // humanized). `humanizedGrid` is the grid the applied layer was computed from;
   // when the live `grid` drifts from it we're "pending" — a re-humanize is queued
@@ -84,6 +87,14 @@ function App() {
 
   // GrooVAE humanize only supports 16th-note grids (4/4, 3/4, 5/4).
   const humanizeSupported = !!timeSignature && timeSignature.stepsPerBeat === 4;
+
+  // Start downloading the 8MB model once the grid is shown (and only for
+  // supported signatures) so the first Humanize click is fast, not a download.
+  // Gated on `assetsReady` so on a shared-link load the model doesn't steal
+  // bandwidth from the drum-sample prefetch that gates the UX.
+  useEffect(() => {
+    if (assetsReady && isSetup && humanizeSupported) warmupModel();
+  }, [assetsReady, isSetup, humanizeSupported, warmupModel]);
 
   // Close menu on outside click
   useEffect(() => {
@@ -190,6 +201,11 @@ function App() {
   // While on, edits auto re-humanize after a 5s idle (see the effect below).
   const humanizeAction = useCallback(() => {
     if (!humanizeSupported) return;
+    if (modelPhase === 'error') { // retry the model download from the error popover
+      warmupModel();
+      return;
+    }
+    if (modelPhase !== 'ready') return; // weights still downloading — ignore clicks
     if (humanizePhase === 'error') { // retry from the error popover
       runHumanize(gridRef.current);
       return;
@@ -203,7 +219,7 @@ function App() {
     setHumanizeOn(true);
     // Reuse a remembered layer that still matches the grid; otherwise compute now.
     if (!(perfLayerRef.current && humanizedGrid === g)) runHumanize(g);
-  }, [humanizeSupported, humanizePhase, humanizeOn, humanizedGrid, runHumanize]);
+  }, [humanizeSupported, modelPhase, warmupModel, humanizePhase, humanizeOn, humanizedGrid, runHumanize]);
 
   // While on, re-humanize once the grid has been idle for HUMANIZE_IDLE_MS.
   // Resetting the timer on every grid change debounces rapid edits into a single
@@ -391,17 +407,22 @@ function App() {
   //               re-humanize) -> spinner
   //   pending   : on, grid drifted, waiting on the idle timer to fire -> "!"
   //   on        : humanized and up to date
+  //   loading   : the model (weights.bin) is still downloading -> progress ring
   const humanizeStatus = !humanizeSupported
     ? 'unavailable'
-    : humanizePhase === 'error'
+    : modelPhase === 'error'
       ? 'error'
-      : !humanizeOn
-        ? 'off'
-        : humanizePhase === 'computing'
-          ? 'computing'
-          : humanizePending
-            ? 'pending'
-            : 'on';
+      : modelPhase !== 'ready'
+        ? 'loading'
+        : humanizePhase === 'error'
+          ? 'error'
+          : !humanizeOn
+            ? 'off'
+            : humanizePhase === 'computing'
+              ? 'computing'
+              : humanizePending
+                ? 'pending'
+                : 'on';
 
   const handlePreview = (sig) => {
     setPreviewSig(sig);
@@ -458,6 +479,13 @@ function App() {
   const removeMeasure = (measureIndex) => {
     setGrid(prevGrid => calculateGridWithRemovedMeasure(prevGrid, measureIndex, timeSignature));
   };
+
+  // Gate all UX until the drum samples are warm in the HTTP cache so the first
+  // Play/preview gesture decodes from cache instead of stalling on the network.
+  // Covers the hash-restore path (isSetup starts true) too.
+  if (!assetsReady) {
+    return <LoadingScreen progress={assetsProgress} />;
+  }
 
   if (!isSetup) {
     return (
@@ -560,6 +588,7 @@ function App() {
             zoom={zoom}
             setZoom={setZoom}
             humanizeStatus={humanizeStatus}
+            humanizeProgress={modelProgress}
             onHumanize={humanizeAction}
           />
         </div>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -34,10 +34,19 @@ const mockUseHumanize = {
     phase: 'idle',
     compute: vi.fn().mockResolvedValue(null),
     reset: vi.fn(),
+    warmup: vi.fn(),
+    modelPhase: 'ready',
+    modelProgress: 1,
 };
 
 vi.mock('./hooks/useHumanize', () => ({
     useHumanize: () => mockUseHumanize,
+}));
+
+// Samples are pre-warmed in tests so the app renders past the loading gate.
+const mockUseSamplePreload = { ready: true, progress: 1 };
+vi.mock('./hooks/useSamplePreload', () => ({
+    useSamplePreload: () => mockUseSamplePreload,
 }));
 
 // Mock child components to verify props and interactions
@@ -109,6 +118,11 @@ describe('App', () => {
         mockUseHumanize.phase = 'idle';
         mockUseHumanize.compute.mockResolvedValue(null);
         mockUseHumanize.reset.mockClear();
+        mockUseHumanize.warmup.mockClear();
+        mockUseHumanize.modelPhase = 'ready';
+        mockUseHumanize.modelProgress = 1;
+        mockUseSamplePreload.ready = true;
+        mockUseSamplePreload.progress = 1;
         window.location.hash = '';
     });
 
@@ -274,6 +288,52 @@ describe('App', () => {
 
         expect(screen.getByTestId('humanize-btn')).toHaveAttribute('data-status', 'unavailable');
         fireEvent.keyDown(window, { key: 'h' });
+        expect(mockUseHumanize.compute).not.toHaveBeenCalled();
+    });
+
+    it('warms up the model on entering the sequencer for a supported signature', () => {
+        renderWith44();
+        expect(mockUseHumanize.warmup).toHaveBeenCalled();
+    });
+
+    it('does not warm up the model until the drum samples are ready', () => {
+        mockUseSamplePreload.ready = false;
+        mockUseSamplePreload.progress = 0.3;
+        renderWith44();
+        // The loading screen gates the UX and the 8MB model waits its turn.
+        expect(screen.getByRole('status')).toHaveAttribute('aria-label', expect.stringMatching(/loading sounds/i));
+        expect(screen.queryByTestId('mock-sequencer')).not.toBeInTheDocument();
+        expect(mockUseHumanize.warmup).not.toHaveBeenCalled();
+    });
+
+    it('does not warm up the model for an unsupported signature', () => {
+        const sig = COMMON_SIGNATURES.find((s) => s.name === '6/8');
+        const steps = sig.beats * sig.stepsPerBeat;
+        const grid = Array.from({ length: INSTRUMENTS.length }, () => Array.from({ length: steps }, () => false));
+        window.location.hash = `#120|6/8|black-pearl|${encodeGrid(grid)}|v1`;
+        render(<App />);
+        expect(mockUseHumanize.warmup).not.toHaveBeenCalled();
+    });
+
+    it('shows "loading" and ignores clicks while the model is downloading', async () => {
+        mockUseHumanize.modelPhase = 'loading';
+        mockUseHumanize.modelProgress = 0.5;
+        renderWith44();
+        const btn = screen.getByTestId('humanize-btn');
+        expect(btn).toHaveAttribute('data-status', 'loading');
+        await act(async () => { fireEvent.click(btn); });
+        expect(mockUseHumanize.compute).not.toHaveBeenCalled();
+        expect(screen.getByTestId('humanize-btn')).toHaveAttribute('data-status', 'loading');
+    });
+
+    it('retries the model download from the error state on click', async () => {
+        mockUseHumanize.modelPhase = 'error';
+        renderWith44();
+        const btn = screen.getByTestId('humanize-btn');
+        expect(btn).toHaveAttribute('data-status', 'error');
+        mockUseHumanize.warmup.mockClear();
+        await act(async () => { fireEvent.click(btn); });
+        expect(mockUseHumanize.warmup).toHaveBeenCalled();
         expect(mockUseHumanize.compute).not.toHaveBeenCalled();
     });
 

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -11,7 +11,7 @@ const ACTION_DELAY_MS = 200;
 
 export default function Controls({
     isPlaying, togglePlay, bpm, setBpm, autoScroll, setAutoScroll, canScroll, zoom, setZoom,
-    humanizeStatus, onHumanize,
+    humanizeStatus, humanizeProgress, onHumanize,
 }) {
     const zoomToggleTimeoutRef = useRef(null);
     const autoScrollToggleTimeoutRef = useRef(null);
@@ -101,7 +101,7 @@ export default function Controls({
             <div className="flex-1 flex items-center justify-end gap-3 ml-0">
 
                 {/* Humanize toggle (off / on / pending) */}
-                <HumanizeButton status={humanizeStatus} onClick={onHumanize} />
+                <HumanizeButton status={humanizeStatus} progress={humanizeProgress} onClick={onHumanize} />
 
                 {/* Zoom Toggle */}
                 <button

--- a/src/components/HumanizeButton.jsx
+++ b/src/components/HumanizeButton.jsx
@@ -10,6 +10,27 @@ const POPOVER_COPY = {
     error: "Couldn't load the humanize model. Check your connection, then retry.",
 };
 
+// Small ring that fills clockwise with `progress` (0..1), wrapping the humanize
+// icon while the model downloads. r=15 in a 36-box -> circumference ~94.2.
+const RING_CIRC = 2 * Math.PI * 15;
+
+function ProgressRing({ progress }) {
+    const p = Math.max(0, Math.min(1, progress));
+    return (
+        <span className="relative w-6 h-6 grid place-items-center">
+            <svg viewBox="0 0 36 36" className="absolute inset-0 w-full h-full -rotate-90">
+                <circle cx="18" cy="18" r="15" fill="none" strokeWidth="3" className="stroke-surface-3" />
+                <circle
+                    cx="18" cy="18" r="15" fill="none" strokeWidth="3" strokeLinecap="round"
+                    className="stroke-primary transition-[stroke-dasharray] duration-200 ease-out"
+                    strokeDasharray={`${p * RING_CIRC} ${RING_CIRC}`}
+                />
+            </svg>
+            <Icon id="humanize" className="w-3 h-3 text-fg-muted" />
+        </span>
+    );
+}
+
 const TITLES = {
     off: "Humanize the beat",
     on: "Humanized — click to turn off",
@@ -27,17 +48,20 @@ const TITLES = {
  * unavailable (incompatible time signature).
  *
  * props:
- *   status  - 'off' | 'on' | 'pending' | 'computing' | 'error' | 'unavailable'
- *   onClick - toggle on/off (or retry from the error popover)
+ *   status   - 'off' | 'on' | 'pending' | 'computing' | 'error' | 'unavailable' | 'loading'
+ *   progress - 0..1 model-download progress (only used by 'loading')
+ *   onClick  - toggle on/off (or retry from the error popover)
  */
-export default function HumanizeButton({ status, onClick }) {
+export default function HumanizeButton({ status, progress = 0, onClick }) {
     const [popoverOpen, setPopoverOpen] = useState(false);
     const wrapperRef = useRef(null);
 
-    const blocked = status === "unavailable" || status === "error";
+    const loading = status === "loading";
+    const blocked = status === "unavailable" || status === "error" || loading;
     const active = status === "on" || status === "pending" || status === "computing";
     const computing = status === "computing";
     const pending = status === "pending";
+    const pct = Math.round(Math.max(0, Math.min(1, progress)) * 100);
 
     useEffect(() => {
         if (!popoverOpen) return undefined;
@@ -54,18 +78,34 @@ export default function HumanizeButton({ status, onClick }) {
     }, [popoverOpen]);
 
     if (blocked) {
+        const popoverText = loading
+            ? `Getting the humanize model ready — this only happens once. ${pct}%`
+            : POPOVER_COPY[status];
+        const ariaLabel = loading
+            ? `Humanize model loading, ${pct} percent`
+            : "Humanization unavailable. Show details.";
         return (
-            <div className="relative flex-none" ref={wrapperRef}>
+            <div
+                className="relative flex-none"
+                ref={wrapperRef}
+                // Hover-to-open only for the loading popover (per the spec); the
+                // unavailable/error popovers stay click/focus-only as before.
+                onMouseEnter={loading ? () => setPopoverOpen(true) : undefined}
+                onMouseLeave={loading ? () => setPopoverOpen(false) : undefined}
+            >
                 <button
                     type="button"
                     onClick={() => setPopoverOpen((o) => !o)}
                     onFocus={() => setPopoverOpen(true)}
                     className="w-8 h-8 flex items-center rounded-sm justify-center bg-surface-5"
                     aria-disabled="true"
-                    aria-label="Humanization unavailable. Show details."
+                    aria-busy={loading || undefined}
+                    aria-label={ariaLabel}
                     aria-describedby={popoverOpen ? "humanize-popover" : undefined}
                 >
-                    <Icon id="humanize" className="w-4 h-4 text-fg-muted opacity-30" />
+                    {loading
+                        ? <ProgressRing progress={progress} />
+                        : <Icon id="humanize" className="w-4 h-4 text-fg-muted opacity-30" />}
                 </button>
                 {popoverOpen && (
                     <div
@@ -74,7 +114,7 @@ export default function HumanizeButton({ status, onClick }) {
                         className="absolute top-full right-0 mt-2 w-56 z-[100] bg-surface-3 border border-border-default rounded-sm p-3 text-xs text-fg-secondary shadow-lg animate-in fade-in duration-150"
                     >
                         <div className="absolute -top-1 right-3 w-2 h-2 bg-surface-3 border-l border-t border-border-default rotate-45" />
-                        <p>{POPOVER_COPY[status]}</p>
+                        <p>{popoverText}</p>
                         {status === "error" && (
                             <button
                                 onClick={() => { setPopoverOpen(false); onClick(); }}

--- a/src/components/HumanizeButton.test.jsx
+++ b/src/components/HumanizeButton.test.jsx
@@ -72,6 +72,49 @@ describe('HumanizeButton', () => {
             fireEvent.keyDown(document, { key: 'Escape' });
             expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
         });
+
+        it('does not open on hover (click/focus only; hover is loading-only)', () => {
+            const { container } = setup('unavailable');
+            fireEvent.mouseEnter(container.firstChild);
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('loading (model downloading)', () => {
+        const renderLoading = (progress = 0.5) => {
+            const onClick = vi.fn();
+            const utils = render(<HumanizeButton status="loading" progress={progress} onClick={onClick} />);
+            return { onClick, ...utils };
+        };
+
+        it('is non-interactive, busy, and shows a progress ring', () => {
+            const { onClick, container } = renderLoading(0.5);
+            const btn = screen.getByRole('button');
+            expect(btn).toHaveAttribute('aria-disabled', 'true');
+            expect(btn).toHaveAttribute('aria-busy', 'true');
+            // The ring is an SVG with a progress stroke; the person icon sits inside it.
+            expect(container.querySelector('svg circle.stroke-primary')).toBeTruthy();
+            expect(useHref(container)).toBe('#icon-humanize');
+            fireEvent.click(btn);
+            expect(onClick).not.toHaveBeenCalled();
+        });
+
+        it('shows a friendly popover with the percent on click', () => {
+            renderLoading(0.42);
+            fireEvent.click(screen.getByRole('button'));
+            const tip = screen.getByRole('tooltip');
+            expect(tip).toHaveTextContent(/only happens once/i);
+            expect(tip).toHaveTextContent('42%');
+        });
+
+        it('opens the popover on hover', () => {
+            const { container } = renderLoading();
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+            fireEvent.mouseEnter(container.firstChild);
+            expect(screen.getByRole('tooltip')).toBeInTheDocument();
+            fireEvent.mouseLeave(container.firstChild);
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+        });
     });
 
     describe('error', () => {

--- a/src/components/LoadingScreen.jsx
+++ b/src/components/LoadingScreen.jsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+import { useEffect, useState } from 'react';
+import { IconSprite, Icon } from './Icons';
+
+const ANTI_FLASH_MS = 150;
+
+/**
+ * Brief branded loading screen shown while the drum samples warm into the HTTP
+ * cache, before any UX. The content stays invisible for a short delay so fast
+ * connections (loader unmounted in well under the delay) never see a flash.
+ *
+ * props:
+ *   progress - 0..1 sample-prefetch progress for the bar.
+ */
+export default function LoadingScreen({ progress = 0 }) {
+    const pct = Math.round(Math.max(0, Math.min(1, progress)) * 100);
+    const [shown, setShown] = useState(false);
+
+    useEffect(() => {
+        const t = setTimeout(() => setShown(true), ANTI_FLASH_MS);
+        return () => clearTimeout(t);
+    }, []);
+
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            aria-label={`Loading sounds, ${pct} percent`}
+            className="min-w-[360px] min-h-screen w-full flex flex-col items-center justify-center bg-surface-0 p-6"
+        >
+            <IconSprite />
+            {/* Anti-flash: stay invisible until the delay passes so a loader that
+                unmounts quickly is never visibly painted. */}
+            <div className={`flex flex-col items-center transition-opacity duration-300 ${shown ? 'opacity-100' : 'opacity-0'}`}>
+                <h1 className="text-3xl font-black tracking-tighter text-fg mb-4 uppercase flex items-center justify-center gap-3">
+                    <Icon id="logo" className="w-12 h-12" />
+                    Quick Beats
+                </h1>
+                <p className="text-fg-muted text-sm font-mono uppercase tracking-[0.2em] mb-6">
+                    Loading sounds…
+                </p>
+                <div className="w-56 h-1 bg-surface-3 rounded-full overflow-hidden">
+                    <div
+                        className="h-full bg-primary transition-[width] duration-200 ease-out"
+                        style={{ width: `${pct}%` }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/LoadingScreen.test.jsx
+++ b/src/components/LoadingScreen.test.jsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import LoadingScreen from './LoadingScreen';
+
+describe('LoadingScreen', () => {
+    it('renders the brand and a status with the percent', () => {
+        render(<LoadingScreen progress={0.5} />);
+        expect(screen.getByText('Quick Beats')).toBeInTheDocument();
+        expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading sounds, 50 percent');
+    });
+
+    it('drives the progress bar width from progress', () => {
+        const { container } = render(<LoadingScreen progress={0.25} />);
+        const bar = container.querySelector('.bg-primary');
+        expect(bar).toHaveStyle({ width: '25%' });
+    });
+
+    it('clamps out-of-range progress', () => {
+        render(<LoadingScreen progress={2} />);
+        expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading sounds, 100 percent');
+    });
+});

--- a/src/hooks/useHumanize.js
+++ b/src/hooks/useHumanize.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: ISC
 
 import { useCallback, useRef, useState } from 'react';
-import { computeHumanization } from '../utils/grooveClient';
+import { computeHumanization, warmupWeights } from '../utils/grooveClient';
 
 /**
  * GrooVAE model lifecycle: a `compute` that runs the model in a Web Worker
@@ -12,10 +12,37 @@ import { computeHumanization } from '../utils/grooveClient';
  * (it's triggered only by the user pressing the Humanize button).
  *
  * phase: 'idle' | 'computing' | 'ready' | 'error'
+ *
+ * Separately tracks the one-time model (weights.bin) download so the App can
+ * start it as soon as the grid is shown and reflect progress on the button:
+ * modelPhase: 'idle' | 'loading' | 'ready' | 'error', modelProgress: 0..1.
  */
 export function useHumanize() {
     const [phase, setPhase] = useState('idle');
     const reqIdRef = useRef(0);
+    const [modelPhase, setModelPhase] = useState('idle');
+    const [modelProgress, setModelProgress] = useState(0);
+    const warmStartedRef = useRef(false);
+
+    /**
+     * Begin (or retry) the background weight download. Idempotent while loading
+     * or ready; a previous error resets so this re-attempts.
+     */
+    const warmup = useCallback(() => {
+        if (warmStartedRef.current) return;
+        warmStartedRef.current = true;
+        setModelProgress(0); // reset so a retry doesn't flash the prior attempt's percent
+        setModelPhase('loading');
+        warmupWeights((p) => setModelProgress(p))
+            .then(() => {
+                setModelProgress(1);
+                setModelPhase('ready');
+            })
+            .catch(() => {
+                warmStartedRef.current = false; // allow a retry
+                setModelPhase('error');
+            });
+    }, []);
 
     /**
      * Compute the performance layer off the main thread. Resolves to the layer,
@@ -49,5 +76,5 @@ export function useHumanize() {
         setPhase('idle');
     }, []);
 
-    return { phase, compute, reset };
+    return { phase, compute, reset, warmup, modelPhase, modelProgress };
 }

--- a/src/hooks/useHumanize.test.js
+++ b/src/hooks/useHumanize.test.js
@@ -6,8 +6,10 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const computeHumanization = vi.fn();
+const warmupWeights = vi.fn();
 vi.mock('../utils/grooveClient', () => ({
     computeHumanization: (...a) => computeHumanization(...a),
+    warmupWeights: (...a) => warmupWeights(...a),
 }));
 
 import { useHumanize } from './useHumanize';
@@ -19,11 +21,67 @@ describe('useHumanize', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         computeHumanization.mockResolvedValue(fakePerf());
+        warmupWeights.mockResolvedValue(undefined);
     });
 
     it('starts idle', () => {
         const { result } = renderHook(() => useHumanize());
         expect(result.current.phase).toBe('idle');
+    });
+
+    it('starts with the model unloaded (modelPhase idle)', () => {
+        const { result } = renderHook(() => useHumanize());
+        expect(result.current.modelPhase).toBe('idle');
+        expect(result.current.modelProgress).toBe(0);
+    });
+
+    it('warmup walks loading -> ready, forwarding progress', async () => {
+        let reportProgress;
+        warmupWeights.mockImplementation((onProgress) => {
+            reportProgress = onProgress;
+            return new Promise((resolve) => { warmupWeights.resolve = resolve; });
+        });
+        const { result } = renderHook(() => useHumanize());
+
+        act(() => { result.current.warmup(); });
+        expect(result.current.modelPhase).toBe('loading');
+
+        act(() => { reportProgress(0.4); });
+        expect(result.current.modelProgress).toBeCloseTo(0.4);
+
+        await act(async () => { warmupWeights.resolve(); });
+        expect(result.current.modelPhase).toBe('ready');
+        expect(result.current.modelProgress).toBe(1);
+    });
+
+    it('warmup goes to error when the download rejects', async () => {
+        warmupWeights.mockRejectedValue(new Error('offline'));
+        const { result } = renderHook(() => useHumanize());
+        await act(async () => { result.current.warmup(); });
+        await waitFor(() => expect(result.current.modelPhase).toBe('error'));
+    });
+
+    it('retry after an error resets progress so the prior percent does not flash', async () => {
+        let rejectFn;
+        let reportProgress;
+        warmupWeights.mockImplementationOnce((onProgress) => {
+            reportProgress = onProgress;
+            return new Promise((_, rej) => { rejectFn = rej; });
+        });
+        const { result } = renderHook(() => useHumanize());
+
+        act(() => { result.current.warmup(); });
+        act(() => { reportProgress(0.7); });
+        expect(result.current.modelProgress).toBeCloseTo(0.7);
+
+        await act(async () => { rejectFn(new Error('offline')); });
+        expect(result.current.modelPhase).toBe('error');
+
+        // Retry: the ring snaps back to 0 immediately rather than showing 70%.
+        warmupWeights.mockImplementationOnce(() => new Promise(() => {})); // stays loading
+        act(() => { result.current.warmup(); });
+        expect(result.current.modelProgress).toBe(0);
+        expect(result.current.modelPhase).toBe('loading');
     });
 
     it('compute returns null for an empty grid without invoking the worker', async () => {

--- a/src/hooks/useSamplePreload.js
+++ b/src/hooks/useSamplePreload.js
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+import { useEffect, useRef, useState } from 'react';
+import { prefetchKitSamples } from '../utils/preloadSamples';
+import { DEFAULT_KIT_ID } from '../data/kit';
+
+/**
+ * Warms the drum samples into the HTTP cache on mount and reports progress so
+ * the app can show a brief loading screen before any UX. Kept as its own hook
+ * (rather than inlined in App) so tests can mock it and skip the gate.
+ *
+ * @returns {{ ready: boolean, progress: number }}
+ */
+export function useSamplePreload() {
+    const [ready, setReady] = useState(false);
+    const [progress, setProgress] = useState(0);
+    const startedRef = useRef(false);
+
+    useEffect(() => {
+        // Guard StrictMode's double-invoke so the prefetch fires once. We don't
+        // gate the resulting setState on a cleanup flag: App is the root and
+        // never truly unmounts here, and gating would let StrictMode's first
+        // cleanup suppress the only prefetch's completion (leaving us stuck on
+        // the loading screen forever).
+        if (startedRef.current) return;
+        startedRef.current = true;
+
+        prefetchKitSamples(DEFAULT_KIT_ID, setProgress)
+            .catch(() => { /* prefetch never rejects, but never block the UI on it */ })
+            .finally(() => setReady(true));
+    }, []);
+
+    return { ready, progress };
+}

--- a/src/hooks/useSamplePreload.test.js
+++ b/src/hooks/useSamplePreload.test.js
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+import { StrictMode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const prefetchKitSamples = vi.fn();
+vi.mock('../utils/preloadSamples', () => ({
+    prefetchKitSamples: (...a) => prefetchKitSamples(...a),
+}));
+
+import { useSamplePreload } from './useSamplePreload';
+
+describe('useSamplePreload', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('starts not-ready and flips ready once the prefetch resolves', async () => {
+        let finish;
+        prefetchKitSamples.mockImplementation(() => new Promise((res) => { finish = res; }));
+        const { result } = renderHook(() => useSamplePreload());
+
+        expect(result.current.ready).toBe(false);
+        await act(async () => { finish(); });
+        await waitFor(() => expect(result.current.ready).toBe(true));
+    });
+
+    it('forwards prefetch progress', async () => {
+        let report;
+        prefetchKitSamples.mockImplementation((_kit, onProgress) => {
+            report = onProgress;
+            return Promise.resolve();
+        });
+        const { result } = renderHook(() => useSamplePreload());
+        act(() => { report(0.5); });
+        expect(result.current.progress).toBeCloseTo(0.5);
+    });
+
+    it('under StrictMode, prefetches once and still becomes ready', async () => {
+        prefetchKitSamples.mockResolvedValue(undefined);
+        const { result } = renderHook(() => useSamplePreload(), { wrapper: StrictMode });
+        // StrictMode double-invokes the mount effect; the prefetch must fire once
+        // and its completion must still flip `ready` (regression: cleanup flag
+        // used to suppress it, leaving the app stuck on the loading screen).
+        expect(prefetchKitSamples).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(result.current.ready).toBe(true));
+    });
+
+    it('becomes ready even if the prefetch rejects', async () => {
+        prefetchKitSamples.mockRejectedValue(new Error('boom'));
+        const { result } = renderHook(() => useSamplePreload());
+        await waitFor(() => expect(result.current.ready).toBe(true));
+    });
+});

--- a/src/utils/grooveClient.js
+++ b/src/utils/grooveClient.js
@@ -9,13 +9,27 @@
 let worker = null;
 let seq = 0;
 const pending = new Map();
+// Single in-flight/settled warmup (weight preload). Type-tagged messages from
+// the worker ({ type: 'progress' | 'ready' | 'error' }) drive it.
+let warmup = null;
 
 const ensureWorker = () => {
     if (worker) return worker;
     worker = new Worker(new URL('../workers/grooveWorker.js', import.meta.url), {
         type: 'module',
     });
-    worker.onmessage = ({ data: { id, perf, error } }) => {
+    worker.onmessage = ({ data }) => {
+        // Warmup messages are type-tagged (no request id).
+        if (data.type) {
+            if (data.type === 'progress') warmup?.onProgress?.(data.progress);
+            else if (data.type === 'ready') warmup?.resolve();
+            else if (data.type === 'error') {
+                warmup?.reject(new Error(data.error || 'groove warmup error'));
+                warmup = null; // let a retry re-warm
+            }
+            return;
+        }
+        const { id, perf, error } = data;
         const entry = pending.get(id);
         if (!entry) return;
         pending.delete(id);
@@ -26,6 +40,8 @@ const ensureWorker = () => {
         const err = new Error(event.message || 'groove worker error');
         pending.forEach((entry) => entry.reject(err));
         pending.clear();
+        warmup?.reject(err);
+        warmup = null;
         // A worker-level failure (e.g. a module that won't load) leaves the worker
         // permanently dead. Discard it so the next call — including a Retry — spins
         // up a fresh one instead of posting into the void.
@@ -46,6 +62,28 @@ export const computeHumanization = (grid, bpm) =>
         ensureWorker().postMessage({ id, grid, bpm });
     });
 
+/**
+ * Start downloading the GrooVAE weights ahead of the first humanize, off the
+ * main thread. Deduped: repeated calls return the same promise (and update the
+ * progress callback). Resolves when the weights are loaded; rejects on failure
+ * (clearing state so a later call retries).
+ *
+ * @param {(progress: number) => void} [onProgress] download progress 0..1.
+ * @returns {Promise<void>}
+ */
+export const warmupWeights = (onProgress) => {
+    if (warmup) {
+        if (onProgress) warmup.onProgress = onProgress;
+        return warmup.promise;
+    }
+    let resolve;
+    let reject;
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+    warmup = { promise, resolve, reject, onProgress };
+    ensureWorker().postMessage({ type: 'warmup' });
+    return promise;
+};
+
 // Test seam: tear down the worker + pending requests.
 export const __resetGrooveClient = () => {
     if (worker) {
@@ -53,5 +91,6 @@ export const __resetGrooveClient = () => {
     }
     worker = null;
     pending.clear();
+    warmup = null;
     seq = 0;
 };

--- a/src/utils/grooveClient.test.js
+++ b/src/utils/grooveClient.test.js
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: ISC
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { computeHumanization, __resetGrooveClient } from './grooveClient';
+import { computeHumanization, warmupWeights, __resetGrooveClient } from './grooveClient';
 
-// Minimal Worker stub: echoes back a computed perf (or an error) per message id.
+// Minimal Worker stub: echoes back a computed perf (or an error) per message id,
+// and answers a { type: 'warmup' } with a progress tick then 'ready'.
 class FakeWorker {
     constructor() {
         this.onmessage = null;
@@ -14,6 +15,18 @@ class FakeWorker {
     }
     postMessage(msg) {
         FakeWorker.lastMessage = msg;
+        if (msg.type === 'warmup') {
+            queueMicrotask(() => {
+                if (!this.onmessage) return;
+                if (FakeWorker.warmupFails) {
+                    this.onmessage({ data: { type: 'error', error: 'warmup failed' } });
+                    return;
+                }
+                this.onmessage({ data: { type: 'progress', progress: 0.5 } });
+                this.onmessage({ data: { type: 'ready' } });
+            });
+            return;
+        }
         const { id, grid } = msg;
         queueMicrotask(() => {
             if (!this.onmessage) return;
@@ -24,10 +37,12 @@ class FakeWorker {
     terminate() {}
 }
 FakeWorker.instances = [];
+FakeWorker.warmupFails = false;
 
 describe('grooveClient', () => {
     beforeEach(() => {
         FakeWorker.instances = [];
+        FakeWorker.warmupFails = false;
         vi.stubGlobal('Worker', FakeWorker);
     });
     afterEach(() => {
@@ -54,6 +69,28 @@ describe('grooveClient', () => {
 
     it('rejects when the worker reports an error', async () => {
         await expect(computeHumanization('BOOM', 120)).rejects.toThrow('worker failed');
+    });
+
+    it('warmupWeights reports progress and resolves, reusing the one worker for compute', async () => {
+        const onProgress = vi.fn();
+        await warmupWeights(onProgress);
+        expect(onProgress).toHaveBeenCalledWith(0.5);
+        await computeHumanization([[true]], 120);
+        expect(FakeWorker.instances).toHaveLength(1);
+        expect(FakeWorker.instances[0].constructor).toBe(FakeWorker);
+    });
+
+    it('warmupWeights dedupes: a second call returns the same promise', async () => {
+        const p1 = warmupWeights();
+        const p2 = warmupWeights();
+        expect(p1).toBe(p2);
+        await p1;
+        expect(FakeWorker.instances).toHaveLength(1);
+    });
+
+    it('warmupWeights rejects when the worker reports an error', async () => {
+        FakeWorker.warmupFails = true;
+        await expect(warmupWeights()).rejects.toThrow('warmup failed');
     });
 
     it('routes concurrent requests to the right promise by id', async () => {

--- a/src/utils/grooveWeights.js
+++ b/src/utils/grooveWeights.js
@@ -35,14 +35,46 @@ const prod = (shape) => shape.reduce((a, b) => a * b, 1);
 
 let cache = null;
 
+// Read a fetch Response body to an ArrayBuffer, reporting download progress
+// (0..1) against Content-Length when the body is a readable stream. Falls back
+// to arrayBuffer() when there's no stream (e.g. test mocks) — no progress then.
+const readWithProgress = async (res, onProgress) => {
+    const total = Number(res.headers?.get?.('Content-Length')) || 0;
+    if (!onProgress || !res.body?.getReader) {
+        return res.arrayBuffer();
+    }
+    const reader = res.body.getReader();
+    const chunks = [];
+    let received = 0;
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        received += value.length;
+        if (total) onProgress(received / total);
+    }
+    const out = new Uint8Array(received);
+    let offset = 0;
+    for (const chunk of chunks) {
+        out.set(chunk, offset);
+        offset += chunk.length;
+    }
+    onProgress(1);
+    return out.buffer;
+};
+
 /**
  * Fetch + dequantize the GrooVAE weights once. Returns a Map keyed by the
  * tfjs variable name -> { data: Float32Array, shape: number[] }.
  *
  * @param {string} [baseUrl] Base URL for the asset (defaults to Vite's BASE_URL).
+ * @param {(progress: number) => void} [onProgress] download progress 0..1 for weights.bin.
  */
-export const loadWeights = async (baseUrl) => {
-    if (cache) return cache;
+export const loadWeights = async (baseUrl, onProgress) => {
+    if (cache) {
+        onProgress?.(1);
+        return cache;
+    }
     const base = baseUrl ?? (import.meta.env?.BASE_URL ?? '/');
     const root = base.endsWith('/') ? base : base + '/';
 
@@ -53,7 +85,7 @@ export const loadWeights = async (baseUrl) => {
         }),
         fetch(root + MODEL_PATH + 'weights.bin').then((r) => {
             if (!r.ok) throw new Error(`groove weights ${r.status}`);
-            return r.arrayBuffer();
+            return readWithProgress(r, onProgress);
         }),
     ]);
 

--- a/src/utils/grooveWeights.test.js
+++ b/src/utils/grooveWeights.test.js
@@ -105,6 +105,37 @@ describe('grooveWeights', () => {
             expect(fetchMock.mock.calls.length).toBe(callsAfterFirst);
         });
 
+        it('streams weights.bin with progress when the body is readable', async () => {
+            const meta = { weights: { 'a/kernel': { offset: 0, shape: [2, 2] } } };
+            const vals = [0.5, -0.5, 1, -1];
+            const u16 = Uint16Array.from(vals.map(f32ToF16));
+            const bytes = new Uint8Array(u16.buffer);
+            const mid = Math.floor(bytes.length / 2);
+            const chunks = [bytes.slice(0, mid), bytes.slice(mid)];
+            let i = 0;
+            const reader = {
+                read: () => i < chunks.length
+                    ? Promise.resolve({ done: false, value: chunks[i++] })
+                    : Promise.resolve({ done: true, value: undefined }),
+            };
+            const fetchMock = vi.fn((url) =>
+                url.endsWith('meta.json')
+                    ? Promise.resolve({ ok: true, json: () => Promise.resolve(meta) })
+                    : Promise.resolve({
+                        ok: true,
+                        headers: { get: () => String(bytes.length) },
+                        body: { getReader: () => reader },
+                    }),
+            );
+            vi.stubGlobal('fetch', fetchMock);
+
+            const onProgress = vi.fn();
+            const weights = await loadWeights('/base/', onProgress);
+            expect(Array.from(weights.get('a/kernel').data).map((v) => Number(v.toFixed(2)))).toEqual([0.5, -0.5, 1, -1]);
+            expect(onProgress).toHaveBeenCalled();
+            expect(onProgress).toHaveBeenLastCalledWith(1);
+        });
+
         it('throws on HTTP error', async () => {
             vi.stubGlobal(
                 'fetch',

--- a/src/utils/preloadSamples.js
+++ b/src/utils/preloadSamples.js
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+// Warms the HTTP cache with a kit's drum samples so the first play (or Setup
+// preview) decodes from cache instead of stalling on a cold network fetch.
+// Deliberately does NOT create any Tone nodes or an AudioContext — that stays
+// deferred to the first user gesture (see useAudio) to avoid the autoplay
+// console warning. We just download the bytes.
+
+import { KITS } from '../data/kit';
+
+/**
+ * Prefetch every sample of `kitId` into the browser's HTTP cache. Resolves once
+ * all requests settle; never rejects (a failed file just doesn't get cached —
+ * Tone's own fetch on first play is the fallback).
+ *
+ * @param {string} kitId
+ * @param {(progress: number) => void} [onProgress] called with 0..1 as files complete.
+ */
+export const prefetchKitSamples = async (kitId, onProgress) => {
+    const kit = KITS[kitId];
+    if (!kit) {
+        onProgress?.(1);
+        return;
+    }
+
+    const base = import.meta.env?.BASE_URL ?? '/';
+    const urls = Object.values(kit.samples).map((path) => {
+        const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+        return `${base}${cleanPath}`;
+    });
+
+    const total = urls.length;
+    if (total === 0) {
+        onProgress?.(1);
+        return;
+    }
+
+    let done = 0;
+    onProgress?.(0);
+    await Promise.all(
+        urls.map(async (url) => {
+            try {
+                // Consume the body so the response fully lands in cache, then drop it.
+                await (await fetch(url)).blob();
+            } catch {
+                // Swallow — first play falls back to Tone's own fetch.
+            }
+            done += 1;
+            onProgress?.(done / total);
+        }),
+    );
+};

--- a/src/utils/preloadSamples.test.js
+++ b/src/utils/preloadSamples.test.js
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { prefetchKitSamples } from './preloadSamples';
+import { KITS } from '../data/kit';
+
+describe('prefetchKitSamples', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('fetches every sample of the kit and reports progress 0 -> 1', async () => {
+        const fetchMock = vi.fn(() => Promise.resolve({ blob: () => Promise.resolve(new Blob()) }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const onProgress = vi.fn();
+        await prefetchKitSamples('black-pearl', onProgress);
+
+        const sampleCount = Object.keys(KITS['black-pearl'].samples).length;
+        expect(fetchMock).toHaveBeenCalledTimes(sampleCount);
+        expect(onProgress).toHaveBeenNthCalledWith(1, 0);
+        expect(onProgress).toHaveBeenLastCalledWith(1);
+    });
+
+    it('never rejects when a fetch fails (first play falls back to Tone)', async () => {
+        vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('offline'))));
+        const onProgress = vi.fn();
+        await expect(prefetchKitSamples('black-pearl', onProgress)).resolves.toBeUndefined();
+        expect(onProgress).toHaveBeenLastCalledWith(1);
+    });
+
+    it('resolves immediately for an unknown kit', async () => {
+        const onProgress = vi.fn();
+        await prefetchKitSamples('nope', onProgress);
+        expect(onProgress).toHaveBeenCalledWith(1);
+    });
+});

--- a/src/workers/grooveWorker.js
+++ b/src/workers/grooveWorker.js
@@ -12,7 +12,28 @@ import { computePerfLayer } from '../utils/grooveConvert';
 let weightsPromise = null;
 
 self.onmessage = async (e) => {
-    const { id, grid, bpm } = e.data || {};
+    const msg = e.data || {};
+
+    // Warmup: download + dequantize the weights ahead of the first humanize,
+    // streaming progress back so the UI can show a ready-up indicator. Shares
+    // `weightsPromise` with compute, so a later compute reuses these weights.
+    if (msg.type === 'warmup') {
+        try {
+            if (!weightsPromise) {
+                weightsPromise = loadWeights(undefined, (progress) =>
+                    self.postMessage({ type: 'progress', progress }),
+                );
+            }
+            await weightsPromise;
+            self.postMessage({ type: 'ready' });
+        } catch (err) {
+            weightsPromise = null; // allow retry after a transient failure (e.g. offline)
+            self.postMessage({ type: 'error', error: String((err && err.message) || err) });
+        }
+        return;
+    }
+
+    const { id, grid, bpm } = msg;
     try {
         if (!weightsPromise) weightsPromise = loadWeights();
         const weights = await weightsPromise;

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,10 +4,33 @@
 
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { KITS, DEFAULT_KIT_ID } from './src/data/kit.js'
+
+// Inject <link rel="prefetch"> for the default kit's samples into index.html so
+// a static host (GitHub Pages — no Link: preload headers available) starts
+// downloading them during HTML parse, in parallel with the JS bundle, instead
+// of waiting for React to mount and fire the fetch. Sourced from kit.js so it
+// stays in sync, and uses the resolved base so it's correct under /quick-beats/.
+const prefetchKitSamples = () => {
+  let base = '/'
+  return {
+    name: 'prefetch-kit-samples',
+    configResolved(config) { base = config.base },
+    transformIndexHtml() {
+      const kit = KITS[DEFAULT_KIT_ID]
+      if (!kit) return []
+      return Object.values(kit.samples).map((path) => ({
+        tag: 'link',
+        attrs: { rel: 'prefetch', href: base + (path.startsWith('/') ? path.slice(1) : path) },
+        injectTo: 'head',
+      }))
+    },
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
-  plugins: [react()],
+  plugins: [react(), prefetchKitSamples()],
   base: mode === 'production' ? '/quick-beats/' : '/',
   test: {
     globals: true,


### PR DESCRIPTION
Two first-impression fixes for asset loading:

- Drum sounds: prefetch the kit's WAVs into the HTTP cache behind a brief branded loading screen (anti-flash, StrictMode-safe) so the first Play/preview decodes from cache instead of stalling on slow networks. No AudioContext is created before a user gesture. A Vite transformIndexHtml plugin also injects <link rel="prefetch"> for the samples so a static host (GitHub Pages) starts the download during HTML parse, parallel to the bundle.

- Humanize model: download the 8MB weights.bin in the worker as soon as the grid is shown (gated on samples being ready so it doesn't steal bandwidth on shared-link loads), streaming progress to a ring on the Humanize button with a friendly popover. The button is disabled until the model is ready, so the first humanize is fast instead of a hidden one-time download.