### PR TITLE
Robustness: stall timeouts for groove worker requests + warmup

### DIFF
--- a/src/hooks/useHumanize.js
+++ b/src/hooks/useHumanize.js
@@ -64,8 +64,13 @@ export function useHumanize() {
             if (id !== reqIdRef.current) return null; // superseded
             setPhase('ready');
             return perf;
-        } catch {
-            if (id === reqIdRef.current) setPhase('error');
+        } catch (err) {
+            // Superseded computes can reject after the user moved on — ignore
+            // those; only surface (and log) the error for the live request.
+            if (id === reqIdRef.current) {
+                console.warn('[humanize] compute failed', err);
+                setPhase('error');
+            }
             return null;
         }
     }, []);

--- a/src/utils/grooveClient.js
+++ b/src/utils/grooveClient.js
@@ -13,6 +13,53 @@ const pending = new Map();
 // the worker ({ type: 'progress' | 'ready' | 'error' }) drive it.
 let warmup = null;
 
+// If a request neither finishes nor errors within this window — measured from
+// its last sign of life (sent, or a streamed window received) — treat it as
+// stalled: drop the entry and reject so its Promise can't hang forever. The
+// rejection flows to the caller (useHumanize -> phase='error' -> Retry).
+const REQUEST_TIMEOUT_MS = 30000;
+
+const clearEntryTimer = (entry) => {
+    if (entry && entry.timer !== null) {
+        clearTimeout(entry.timer);
+        entry.timer = null;
+    }
+};
+
+// (Re)arm the stall timeout for a pending request. Called when the request is
+// sent and reset on each streamed partial, so it measures silence, not total
+// compute time.
+const armTimeout = (id) => {
+    const entry = pending.get(id);
+    if (!entry) return;
+    clearEntryTimer(entry);
+    entry.timer = setTimeout(() => {
+        pending.delete(id);
+        entry.reject(new Error('groove worker timed out'));
+    }, REQUEST_TIMEOUT_MS);
+};
+
+// Same stall protection for the one-shot warmup: a silent stall during the
+// multi-MB weight download would otherwise hang its Promise forever, leaving
+// the UI stuck on the loading ring with no way to retry. Reset on every
+// progress tick so an honestly-downloading worker is never killed.
+const clearWarmupTimer = () => {
+    if (warmup && warmup.timer !== null) {
+        clearTimeout(warmup.timer);
+        warmup.timer = null;
+    }
+};
+
+const armWarmupTimeout = () => {
+    if (!warmup) return;
+    clearWarmupTimer();
+    warmup.timer = setTimeout(() => {
+        const stalled = warmup;
+        warmup = null; // let a retry re-warm
+        stalled.reject(new Error('groove warmup timed out'));
+    }, REQUEST_TIMEOUT_MS);
+};
+
 const ensureWorker = () => {
     if (worker) return worker;
     worker = new Worker(new URL('../workers/grooveWorker.js', import.meta.url), {
@@ -21,9 +68,19 @@ const ensureWorker = () => {
     worker.onmessage = ({ data }) => {
         // Warmup messages are type-tagged (no request id).
         if (data.type) {
-            if (data.type === 'progress') warmup?.onProgress?.(data.progress);
-            else if (data.type === 'ready') warmup?.resolve(data.backend); // 'wasm' | 'js'
-            else if (data.type === 'error') {
+            if (data.type === 'progress') {
+                warmup?.onProgress?.(data.progress);
+                // A progress tick proves the worker is alive and downloading, so
+                // reset the stall clocks: the warmup's own, plus any compute that
+                // is blocked awaiting the same backend build (no partials stream
+                // until the weights finish loading).
+                armWarmupTimeout();
+                pending.forEach((_entry, pid) => armTimeout(pid));
+            } else if (data.type === 'ready') {
+                clearWarmupTimer();
+                warmup?.resolve(data.backend); // 'wasm' | 'js'
+            } else if (data.type === 'error') {
+                clearWarmupTimer();
                 warmup?.reject(new Error(data.error || 'groove warmup error'));
                 warmup = null; // let a retry re-warm
             }
@@ -33,19 +90,23 @@ const ensureWorker = () => {
         const entry = pending.get(id);
         if (!entry) return;
         if (error) {
+            clearEntryTimer(entry);
             pending.delete(id);
             entry.reject(new Error(error));
         } else if (done === false) {
             entry.onPartial?.(perf); // streamed window; keep the entry pending
+            armTimeout(id); // a window landed — reset the stall clock
         } else {
+            clearEntryTimer(entry);
             pending.delete(id);
             entry.resolve(perf);
         }
     };
     worker.onerror = (event) => {
         const err = new Error(event.message || 'groove worker error');
-        pending.forEach((entry) => entry.reject(err));
+        pending.forEach((entry) => { clearEntryTimer(entry); entry.reject(err); });
         pending.clear();
+        clearWarmupTimer();
         warmup?.reject(err);
         warmup = null;
         // A worker-level failure (e.g. a module that won't load) leaves the worker
@@ -66,8 +127,9 @@ const ensureWorker = () => {
 export const computeHumanization = (grid, bpm, onPartial) =>
     new Promise((resolve, reject) => {
         const id = ++seq;
-        pending.set(id, { resolve, reject, onPartial });
+        pending.set(id, { resolve, reject, onPartial, timer: null });
         ensureWorker().postMessage({ id, grid, bpm });
+        armTimeout(id);
     });
 
 /**
@@ -87,8 +149,9 @@ export const warmupWeights = (onProgress) => {
     let resolve;
     let reject;
     const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
-    warmup = { promise, resolve, reject, onProgress };
+    warmup = { promise, resolve, reject, onProgress, timer: null };
     ensureWorker().postMessage({ type: 'warmup' });
+    armWarmupTimeout();
     return promise;
 };
 
@@ -98,7 +161,9 @@ export const __resetGrooveClient = () => {
         try { worker.terminate(); } catch { /* ignore */ }
     }
     worker = null;
+    pending.forEach((entry) => clearEntryTimer(entry));
     pending.clear();
+    clearWarmupTimer();
     warmup = null;
     seq = 0;
 };

--- a/src/utils/grooveClient.test.js
+++ b/src/utils/grooveClient.test.js
@@ -16,6 +16,7 @@ class FakeWorker {
     postMessage(msg) {
         FakeWorker.lastMessage = msg;
         if (msg.type === 'warmup') {
+            if (FakeWorker.warmupHangs) return; // never responds — stalled download
             queueMicrotask(() => {
                 if (!this.onmessage) return;
                 if (FakeWorker.warmupFails) {
@@ -28,6 +29,14 @@ class FakeWorker {
             return;
         }
         const { id, grid } = msg;
+        if (grid === 'HANG') return; // never responds — simulates a stalled worker
+        if (grid === 'SLOWBUILD') {
+            // A slow-but-honest cold build: emit a liveness progress at 20s, then
+            // finish at 40s. Neither gap exceeds the 30s stall window.
+            setTimeout(() => this.onmessage?.({ data: { type: 'progress', progress: 0.3 } }), 20000);
+            setTimeout(() => this.onmessage?.({ data: { id, perf: [['ok']], done: true } }), 40000);
+            return;
+        }
         queueMicrotask(() => {
             if (!this.onmessage) return;
             if (grid === 'BOOM') this.onmessage({ data: { id, error: 'worker failed' } });
@@ -42,11 +51,13 @@ class FakeWorker {
 }
 FakeWorker.instances = [];
 FakeWorker.warmupFails = false;
+FakeWorker.warmupHangs = false;
 
 describe('grooveClient', () => {
     beforeEach(() => {
         FakeWorker.instances = [];
         FakeWorker.warmupFails = false;
+        FakeWorker.warmupHangs = false;
         vi.stubGlobal('Worker', FakeWorker);
     });
     afterEach(() => {
@@ -103,6 +114,46 @@ describe('grooveClient', () => {
     it('warmupWeights rejects when the worker reports an error', async () => {
         FakeWorker.warmupFails = true;
         await expect(warmupWeights()).rejects.toThrow('warmup failed');
+    });
+
+    it('rejects a stalled request after the timeout and drops it', async () => {
+        vi.useFakeTimers();
+        try {
+            const p = computeHumanization('HANG', 120);
+            p.catch(() => {}); // pre-attach so the advance doesn't trip unhandled-rejection
+            await vi.advanceTimersByTimeAsync(30000);
+            await expect(p).rejects.toThrow(/timed out/i);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('rejects warmup after the timeout when the worker goes silent, then allows a retry', async () => {
+        FakeWorker.warmupHangs = true;
+        vi.useFakeTimers();
+        try {
+            const p = warmupWeights();
+            p.catch(() => {}); // pre-attach so the advance doesn't trip unhandled-rejection
+            await vi.advanceTimersByTimeAsync(30000);
+            await expect(p).rejects.toThrow(/warmup timed out/i);
+        } finally {
+            vi.useRealTimers();
+        }
+        // The stalled warmup was cleared, so a fresh attempt can succeed.
+        FakeWorker.warmupHangs = false;
+        await expect(warmupWeights()).resolves.toBe('wasm');
+    });
+
+    it('resets a pending compute timer on worker progress, so a slow build does not spuriously time out', async () => {
+        vi.useFakeTimers();
+        try {
+            const p = computeHumanization('SLOWBUILD', 120);
+            await vi.advanceTimersByTimeAsync(20000); // progress tick re-arms the stall clock
+            await vi.advanceTimersByTimeAsync(20000); // done lands at t=40s; no 30s silence
+            await expect(p).resolves.toEqual([['ok']]);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('routes concurrent requests to the right promise by id', async () => {

--- a/src/workers/grooveWorker.js
+++ b/src/workers/grooveWorker.js
@@ -55,7 +55,10 @@ self.onmessage = async (e) => {
 
     const { id, grid, bpm } = msg;
     try {
-        const backend = await buildBackend();
+        // Report download progress even on a compute-triggered cold build (no
+        // prior warmup): it doubles as a liveness signal so the client doesn't
+        // mistake a slow-but-honest weight load for a stall.
+        const backend = await buildBackend((progress) => self.postMessage({ type: 'progress', progress }));
         // Stream each window's cumulative layer so multi-bar beats update as
         // they compute; the final message carries done:true.
         const perf = computePerfLayer(backend, grid, bpm, (partial) =>


### PR DESCRIPTION
A compute or warmup request whose worker went silent (e.g. a stalled weight download on a flaky connection) left its Promise pending forever — the humanize button could lock on the loading ring with no way to retry.

- Add a 30s stall timeout to each compute request and to the one-shot warmup; on fire, drop the entry and reject so the UI surfaces an error + Retry.
- Treat a worker `progress` tick as a global liveness signal that resets the warmup clock and every pending compute timer, so a slow-but-honest weight load is never mistaken for a stall. Emit progress on compute-triggered cold builds too, covering the no-prior-warmup path.
- Log compute error detail (live request only) for observability.