### PR TITLE
Accessibility: keyboard + screen-reader support for the step grid

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@
 
 import js from '@eslint/js'
 import globals from 'globals'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
@@ -16,6 +17,7 @@ export default defineConfig([
     files: ['**/*.{js,jsx}'],
     extends: [
       js.configs.recommended,
+      jsxA11y.flatConfigs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
@@ -30,6 +32,11 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]', argsIgnorePattern: '^_' }],
+      // ARIA-correctness rules stay errors (they guard the sequencer grid work).
+      // These two flag pre-existing click-to-seek / click-backdrop divs that are
+      // out of scope for the accessibility milestone — surface as warnings.
+      'jsx-a11y/no-static-element-interactions': 'warn',
+      'jsx-a11y/click-events-have-key-events': 'warn',
     },
   },
   // Test files configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "assemblyscript": "^0.28.18",
         "autoprefixer": "^10.5.0",
         "eslint": "^10.4.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
@@ -1832,6 +1833,106 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/assemblyscript": {
       "version": "0.28.18",
       "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.28.18.tgz",
@@ -1865,6 +1966,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
@@ -1883,6 +1991,16 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/automation-events": {
       "version": "7.1.15",
@@ -1966,6 +2084,42 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/balanced-match": {
@@ -2066,6 +2220,56 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
@@ -2096,6 +2300,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2147,6 +2358,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2159,6 +2377,60 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/debug": {
@@ -2193,6 +2465,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2220,12 +2528,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.336",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
       "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.1",
@@ -2254,12 +2584,161 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2338,6 +2817,77 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -2576,6 +3126,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -2605,6 +3171,57 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2613,6 +3230,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob-parent": {
@@ -2641,12 +3315,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2656,6 +3373,77 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -2725,6 +3513,140 @@
         "node": ">=8"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2733,6 +3655,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -2748,10 +3706,205 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2916,6 +4069,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2924,6 +4093,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/levn": {
@@ -3295,6 +4484,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -3368,6 +4567,88 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -3395,6 +4676,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -3487,6 +4786,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -3602,6 +4911,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3653,6 +5006,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -3682,6 +5090,55 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3703,6 +5160,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3746,6 +5279,95 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -3918,6 +5540,103 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/undici": {
@@ -4201,6 +5920,95 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "assemblyscript": "^0.28.18",
     "autoprefixer": "^10.5.0",
     "eslint": "^10.4.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
@@ -44,6 +45,9 @@
   },
   "overrides": {
     "eslint-plugin-react-hooks": {
+      "eslint": "$eslint"
+    },
+    "eslint-plugin-jsx-a11y": {
       "eslint": "$eslint"
     }
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -522,6 +522,8 @@ function App() {
   return (
     <div className="bg-surface-1 h-screen flex flex-col text-fg overflow-hidden w-fit max-w-screen min-w-[360px]">
       <IconSprite />
+      {/* Screen-reader announcement of transport state (visually hidden). */}
+      <div className="sr-only" role="status" aria-live="polite">{isPlaying ? 'Playing' : 'Paused'}</div>
       <div className="flex-1 flex flex-col overflow-hidden">
         <header className="@container flex-none flex items-center justify-between px-2 py-1 md:px-6 md:py-3">
           <div className="flex items-center gap-4">

--- a/src/components/ContextMenu.jsx
+++ b/src/components/ContextMenu.jsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: ISC
 
 import { useRef, useLayoutEffect, useState, useImperativeHandle, forwardRef, Fragment } from 'react';
+import { FILL_MODES } from '../data/sequencerConfig';
 
 const ContextMenu = forwardRef(({ x, y, activeOption, grouping, colInGroup }, ref) => {
     const [offset, setOffset] = useState(0);
@@ -29,9 +30,35 @@ const ContextMenu = forwardRef(({ x, y, activeOption, grouping, colInGroup }, re
         }
     }, [x]);
 
+    // Metadata per fill mode, keyed by id (built once). The `pattern` previews
+    // which cells the mode fills/clears within two groups.
+    const OPTION_META = {
+        repeat: {
+            id: 'repeat',
+            label: 'Repeat',
+            pattern: (idx) => idx % grouping === colInGroup ? 'fill' : 'none'
+        },
+        alternate: {
+            id: 'alternate',
+            label: 'Alternate',
+            pattern: (idx) => {
+                if (idx === colInGroup) return 'fill';
+                if (idx === colInGroup + grouping) return 'clear';
+                return 'none';
+            }
+        },
+        clear: {
+            id: 'clear',
+            label: 'Clear',
+            pattern: (idx) => idx % grouping === colInGroup ? 'clear' : 'none'
+        }
+    };
+
     return (
         <div
             ref={menuRef}
+            role="menu"
+            aria-label="Fill pattern"
             className="fixed z-[100] bg-surface-3 border border-border-default shadow-2xl rounded-lg overflow-hidden pointer-events-none"
             style={{
                 left: x + offset,
@@ -40,29 +67,16 @@ const ContextMenu = forwardRef(({ x, y, activeOption, grouping, colInGroup }, re
             }}
         >
             <div className="flex flex-col p-1 gap-1">
-                {[
-                    {
-                        id: 'repeat',
-                        label: 'Repeat',
-                        pattern: (idx) => idx % grouping === colInGroup ? 'fill' : 'none'
-                    },
-                    {
-                        id: 'alternate',
-                        label: 'Alternate',
-                        pattern: (idx) => {
-                            if (idx === colInGroup) return 'fill';
-                            if (idx === colInGroup + grouping) return 'clear';
-                            return 'none';
-                        }
-                    },
-                    {
-                        id: 'clear',
-                        label: 'Clear',
-                        pattern: (idx) => idx % grouping === colInGroup ? 'clear' : 'none'
-                    }
-                ].map((opt) => (
+                {/* Rendered in the shared FILL_MODES order so the menu and the
+                    keyboard cycling can't drift apart; unknown ids are skipped
+                    rather than crashing the render. */}
+                {FILL_MODES.map((id) => OPTION_META[id]).filter(Boolean).map((opt) => (
                     <div
                         key={opt.id}
+                        id={`fill-${opt.id}`}
+                        role="menuitemradio"
+                        aria-checked={activeOption === opt.id}
+                        aria-label={opt.label}
                         className={`flex items-center cursor-pointer gap-3 px-3 py-2 rounded-md transition-colors ${activeOption === opt.id ? 'bg-primary text-fg' : 'text-fg-secondary'}`}
                     >
                         <span className="text-[10px] font-bold uppercase tracking-wider w-16">{opt.label}</span>

--- a/src/components/Help.jsx
+++ b/src/components/Help.jsx
@@ -81,6 +81,14 @@ export default function Help({ isOpen, onClose, showKeyboardCheatsheet = false }
                                 <div className="font-mono bg-surface-0 border border-border-dim px-2 w-12 text-center py-1 text-fg text-[11px]">?</div>
                                 <div>Show this help</div>
                             </div>
+                            <div className="flex items-center gap-3">
+                                <div className="font-mono bg-surface-0 border border-border-dim px-2 w-12 text-center py-1 text-fg text-[11px]">Arrows</div>
+                                <div>Move between steps</div>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <div className="font-mono bg-surface-0 border border-border-dim px-2 w-12 text-center py-1 text-fg text-[11px]">Enter</div>
+                                <div>Toggle focused step</div>
+                            </div>
                         </div>
                     </HelpSection>
                 )}

--- a/src/components/InstrumentRow.jsx
+++ b/src/components/InstrumentRow.jsx
@@ -21,7 +21,9 @@ export function InstrumentRow({
     setMenuState,
     pendingDelete,
     zoom,
-    visibleRange
+    visibleRange,
+    focusedCol = -1,
+    onFocusCell
 }) {
     const config = ZOOM_CONFIG[zoom];
     const start = visibleRange?.start ?? 0;
@@ -33,18 +35,25 @@ export function InstrumentRow({
     const rightSpacerWidth = Math.max(0, totalWidth - leftSpacerWidth - windowWidth);
 
     return (
-        <div data-grid-row="true" className={`flex items-center ${config.heightClass} group hover:bg-highlight/[0.02]`}>
+        <div data-grid-row="true" role="row" aria-rowindex={rowIdx + 1} className={`flex items-center ${config.heightClass} group hover:bg-highlight/[0.02]`}>
             {/* Sticky Instrument Label - Narrowed for Icons */}
-            <div data-grid-label="true" className={`sticky left-0 ${GRID_LAYOUT.rowLabelClass} flex-shrink-0 flex items-center justify-center z-20 bg-surface-1 h-full shadow-[2px_0_5px_var(--color-surface-1)]`} title={instrument}>
-                <Icon id={INSTRUMENT_ICONS[instrument] || 'kick'} className="w-5 h-5 text-fg-secondary" />
+            {/* The sr-only text is the row header's accessible name (reliable
+                "name from content"); the icon is decorative and title is just the
+                sighted hover tooltip. */}
+            <div data-grid-label="true" role="rowheader" className={`sticky left-0 ${GRID_LAYOUT.rowLabelClass} flex-shrink-0 flex items-center justify-center z-20 bg-surface-1 h-full shadow-[2px_0_5px_var(--color-surface-1)]`} title={instrument}>
+                <span className="sr-only">{instrument}</span>
+                <Icon id={INSTRUMENT_ICONS[instrument] || 'kick'} className="w-5 h-5 text-fg-secondary" aria-hidden="true" />
             </div>
+            {/* The lane and window wrappers are presentational so the gridcells
+                hoist to be owned directly by the row (windowed render). */}
             <div
                 data-grid-lane="true"
+                role="presentation"
                 className={`flex-1 flex h-full relative ${GRID_LAYOUT.rowLaneClass}`}
                 style={{ marginRight: `-${config.groupGap}px` }}
             >
                 {leftSpacerWidth > 0 && <div className="flex-none" style={{ width: `${leftSpacerWidth}px` }} aria-hidden="true" />}
-                <div className="flex-none flex h-full" style={{ width: `${windowWidth}px`, columnGap: `${config.gap}px` }}>
+                <div role="presentation" className="flex-none flex h-full" style={{ width: `${windowWidth}px`, columnGap: `${config.gap}px` }}>
                 {gridRow && gridRow.slice(start, end).map((isActive, offsetIdx) => {
                     const colIdx = start + offsetIdx;
                     const measureIdx = Math.floor(colIdx / stepsPerMeasure);
@@ -53,6 +62,7 @@ export function InstrumentRow({
                             key={colIdx}
                             isActive={isActive}
                             humanized={!!humanizedRow?.[colIdx]}
+                            instrument={instrument}
                             rowIdx={rowIdx}
                             colIdx={colIdx}
                             grouping={grouping}
@@ -60,6 +70,8 @@ export function InstrumentRow({
                             toggleStep={toggleStep}
                             setMenuState={setMenuState}
                             faded={pendingDelete === measureIdx}
+                            isFocused={focusedCol === colIdx}
+                            onFocusCell={onFocusCell}
                         />
                     )
                 })}

--- a/src/components/Pad.jsx
+++ b/src/components/Pad.jsx
@@ -5,7 +5,7 @@
 import { memo, useRef, useCallback } from 'react';
 import { useLongPress } from '../hooks/useLongPress';
 
-export const Pad = ({ isActive, humanized, rowIdx, colIdx, grouping, config, toggleStep, setMenuState, faded }) => {
+export const Pad = ({ isActive, humanized, instrument, rowIdx, colIdx, grouping, config, toggleStep, setMenuState, faded, isFocused, onFocusCell }) => {
     const padRef = useRef(null);
 
     const onLongPress = useCallback(() => {
@@ -16,7 +16,8 @@ export const Pad = ({ isActive, humanized, rowIdx, colIdx, grouping, config, tog
             y: rect.top,
             row: rowIdx,
             col: colIdx,
-            activeOption: null
+            activeOption: null,
+            source: 'pointer'
         });
     }, [rowIdx, colIdx, setMenuState]);
 
@@ -26,22 +27,38 @@ export const Pad = ({ isActive, humanized, rowIdx, colIdx, grouping, config, tog
 
     const [longPressHandlers] = useLongPress({ onLongPress, onClick });
 
+    // The cell is the grid structure (column position, layout); the inner box
+    // is the actual toggle widget a screen reader/keyboard interacts with.
+    const label = `${instrument ? `${instrument}, ` : ''}step ${colIdx + 1}${humanized ? ', humanized' : ''}`;
+
     return (
         <div
-            ref={padRef}
-            {...longPressHandlers}
-            className={`flex-none cursor-pointer touch-pan-x relative ${config.radiusClass}
-                ${isActive
-                    ? (humanized ? "bg-accent" : "bg-primary")
-                    : "bg-surface-5 hover:bg-border-medium"}
-                ${faded ? 'opacity-30 pointer-events-none' : ''}
-            `}
+            role="gridcell"
+            aria-colindex={colIdx + 1}
+            className={`flex-none ${faded ? 'opacity-30 pointer-events-none' : ''}`}
             style={{
                 width: `${config.cellWidth}px`,
                 marginRight: (colIdx + 1) % grouping === 0 ? `${config.groupGap}px` : undefined,
             }}
-            data-testid="pad"
         >
+            <div
+                ref={padRef}
+                role="checkbox"
+                aria-checked={isActive}
+                aria-label={label}
+                tabIndex={isFocused ? 0 : -1}
+                onFocus={() => onFocusCell?.(rowIdx, colIdx)}
+                data-row={rowIdx}
+                data-col={colIdx}
+                {...longPressHandlers}
+                className={`w-full h-full cursor-pointer touch-pan-x relative ${config.radiusClass}
+                    ${isActive
+                        ? (humanized ? "bg-accent" : "bg-primary")
+                        : "bg-surface-5 hover:bg-border-medium"}
+                `}
+                data-testid="pad"
+            >
+            </div>
         </div>
     );
 };

--- a/src/components/Pad.test.jsx
+++ b/src/components/Pad.test.jsx
@@ -117,7 +117,8 @@ describe('Pad', () => {
             x: 125, // 100 + 50/2
             y: 200,
             row: 0,
-            col: 0
+            col: 0,
+            source: 'pointer'
         }));
     });
 
@@ -127,29 +128,53 @@ describe('Pad', () => {
         expect(pad).toHaveClass('touch-pan-x');
     });
 
-    it('applies faded styles when faded prop is true', () => {
+    it('applies faded styles to the cell when faded prop is true', () => {
         render(<Pad {...defaultProps} faded={true} />);
-        const pad = screen.getByTestId('pad');
-        expect(pad).toHaveClass('opacity-30');
-        expect(pad).toHaveClass('pointer-events-none');
+        const cell = screen.getByTestId('pad').parentElement;
+        expect(cell).toHaveClass('opacity-30');
+        expect(cell).toHaveClass('pointer-events-none');
     });
 
     it('does not apply faded styles when faded prop is false', () => {
         render(<Pad {...defaultProps} faded={false} />);
-        const pad = screen.getByTestId('pad');
-        expect(pad).not.toHaveClass('opacity-30');
-        expect(pad).not.toHaveClass('pointer-events-none');
+        const cell = screen.getByTestId('pad').parentElement;
+        expect(cell).not.toHaveClass('opacity-30');
+        expect(cell).not.toHaveClass('pointer-events-none');
     });
 
     it('applies group gap margin on last item in group', () => {
         render(<Pad {...defaultProps} colIdx={3} grouping={4} />);
-        const pad = screen.getByTestId('pad');
-        expect(pad.style.marginRight).toBe('8px');
+        const cell = screen.getByTestId('pad').parentElement;
+        expect(cell.style.marginRight).toBe('8px');
     });
 
     it('does not apply group gap margin on non-last item in group', () => {
         render(<Pad {...defaultProps} colIdx={2} grouping={4} />);
+        const cell = screen.getByTestId('pad').parentElement;
+        expect(cell.style.marginRight).toBe('');
+    });
+
+    it('exposes checkbox semantics reflecting active state', () => {
+        const { rerender } = render(<Pad {...defaultProps} isActive={false} />);
         const pad = screen.getByTestId('pad');
-        expect(pad.style.marginRight).toBe('');
+        expect(pad).toHaveAttribute('role', 'checkbox');
+        expect(pad).toHaveAttribute('aria-checked', 'false');
+        rerender(<Pad {...defaultProps} isActive={true} />);
+        expect(screen.getByTestId('pad')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('labels the pad with instrument and 1-based step, and marks humanized', () => {
+        render(<Pad {...defaultProps} instrument="Snare" colIdx={4} isActive humanized />);
+        const pad = screen.getByTestId('pad');
+        expect(pad).toHaveAttribute('aria-label', 'Snare, step 5, humanized');
+        expect(pad).toHaveAttribute('data-row', '0');
+        expect(pad).toHaveAttribute('data-col', '4');
+    });
+
+    it('wraps the pad in a gridcell carrying the 1-based column index', () => {
+        render(<Pad {...defaultProps} colIdx={4} />);
+        const cell = screen.getByTestId('pad').parentElement;
+        expect(cell).toHaveAttribute('role', 'gridcell');
+        expect(cell).toHaveAttribute('aria-colindex', '5');
     });
 });

--- a/src/components/Sequencer.jsx
+++ b/src/components/Sequencer.jsx
@@ -2,18 +2,19 @@
 //
 // SPDX-License-Identifier: ISC
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { INSTRUMENTS } from "../data/kit";
 import { ZOOM_CONFIG } from "../data/sequencerConfig";
 import { Icon } from "./Icons";
 import ContextMenu from "./ContextMenu";
 import { useSequencerSelection } from "../hooks/useSequencerSelection";
 import { useAutoScroll } from "../hooks/useAutoScroll";
+import { useInputModality } from "../hooks/useInputModality";
 import { SequencerHeader } from "./SequencerHeader";
 import { MemoizedInstrumentRow } from "./InstrumentRow";
 import { MeasureControls } from "./MeasureControls";
 import { PlayheadOverlay } from "./PlayheadOverlay";
-import { getGridOriginOffsetPx, isMobileViewport, xToStep } from "../utils/sequencerGeometry";
+import { getGridOriginOffsetPx, isMobileViewport, scrollTargetForStep, xToStep } from "../utils/sequencerGeometry";
 
 
 
@@ -29,6 +30,20 @@ export default function Sequencer({ isPlaying, togglePlay, grid, humanizedMask, 
         containerWidth: 0,
     });
     const [visibleRange, setVisibleRange] = useState({ start: 0, end: stepCount });
+    // Single roving tab stop for the grid (the pad at this cell has tabIndex 0,
+    // every other pad -1). `navFocusRef` marks a programmatic move so the
+    // focus-into-view effect only steals focus on keyboard navigation, never on
+    // playback auto-scroll.
+    const [focusedCell, setFocusedCell] = useState({ row: 0, col: 0 });
+    const navFocusRef = useRef(false);
+    // Whether the focused pad was reached by keyboard (Tab/arrows) vs pointer —
+    // the :focus-visible distinction. Drives "Smart Space": Space toggles a
+    // keyboard-focused pad but falls through to global play/pause otherwise.
+    const inputModalityRef = useInputModality();
+    const focusViaKeyboardRef = useRef(false);
+    // True while focus is inside the grid. Used to keep the focused cell rendered
+    // (see renderRange) so a scroll can't window it out and drop focus to <body>.
+    const [gridHasFocus, setGridHasFocus] = useState(false);
 
     const { menuState, setMenuState, menuRef } = useSequencerSelection({ onBulkUpdate: bulkUpdateStep });
     
@@ -139,8 +154,129 @@ export default function Sequencer({ isPlaying, togglePlay, grid, humanizedMask, 
         if (isPlaying && typeof togglePlay === 'function') togglePlay();
     };
 
+    // Keyboard grid navigation -------------------------------------------------
+    const rowCount = INSTRUMENTS.length;
+
+    // Clamp the roving focus to the live grid bounds at render time (cheaper and
+    // safer than a clamp effect when the grid shrinks — measure removed / sig
+    // change). The raw `focusedCell` may briefly hold an out-of-range value;
+    // these derived values are what we render and focus with.
+    const focusRow = Math.min(focusedCell.row, rowCount - 1);
+    const focusCol = Math.min(focusedCell.col, Math.max(0, stepCount - 1));
+
+    // While the grid holds focus, force the focused column into the rendered
+    // window so a scroll (wheel, etc.) can't unmount the focused pad and lose
+    // focus. When focus is elsewhere, normal windowing applies.
+    const renderRange = gridHasFocus
+        ? { start: Math.min(visibleRange.start, focusCol), end: Math.max(visibleRange.end, focusCol + 1) }
+        : visibleRange;
+
+    // Move the roving focus to a (clamped) cell and flag it for focus-into-view.
+    const moveFocus = useCallback((row, col) => {
+        const r = Math.max(0, Math.min(rowCount - 1, row));
+        const c = Math.max(0, Math.min(stepCount - 1, col));
+        navFocusRef.current = true;
+        setFocusedCell((prev) => (prev.row === r && prev.col === c ? prev : { row: r, col: c }));
+    }, [rowCount, stepCount]);
+
+    // Keep the roving stop in sync when a pad is focused, recording whether the
+    // focus arrived via keyboard or pointer (used by the Space handler below).
+    const handleFocusCell = useCallback((row, col) => {
+        focusViaKeyboardRef.current = inputModalityRef.current === 'keyboard';
+        setFocusedCell((prev) => (prev.row === row && prev.col === col ? prev : { row, col }));
+    }, [inputModalityRef]);
+
+    // Open the bulk-fill menu for a cell from the keyboard (ContextMenu/Shift+F10).
+    const openFillMenu = useCallback((cell, row, col) => {
+        const rect = cell.getBoundingClientRect();
+        setMenuState({
+            isOpen: true,
+            x: rect.left + rect.width / 2,
+            y: rect.top,
+            row,
+            col,
+            activeOption: 'repeat',
+            source: 'keyboard',
+        });
+    }, [setMenuState]);
+
+    const handleGridKeyDown = useCallback((e) => {
+        if (menuState.isOpen) return; // menu owns the keyboard while open (3c)
+        const cell = e.target.closest?.('[data-col]');
+        if (!cell) return;
+        const row = Number(cell.dataset.row);
+        const col = Number(cell.dataset.col);
+        // A measure pending deletion is non-interactive (pointer-events-none for
+        // the mouse); mirror that for the keyboard — navigation still works, but
+        // editing/menu actions are suppressed.
+        const faded = pendingDelete === Math.floor(col / stepsPerMeasure);
+        let handled = true;
+        switch (e.key) {
+            case 'ArrowRight': moveFocus(row, col + 1); break;
+            case 'ArrowLeft': moveFocus(row, col - 1); break;
+            case 'ArrowDown': moveFocus(row + 1, col); break;
+            case 'ArrowUp': moveFocus(row - 1, col); break;
+            case 'Home': moveFocus(e.ctrlKey ? 0 : row, 0); break;
+            case 'End': moveFocus(e.ctrlKey ? rowCount - 1 : row, stepCount - 1); break;
+            case 'Enter':
+                if (!faded) toggleStep(row, col);
+                break;
+            case ' ':
+                // Smart Space: only a keyboard-focused pad consumes Space (ARIA
+                // checkbox toggle). A pointer-focused pad lets Space bubble to
+                // the global play/pause shortcut.
+                if (!focusViaKeyboardRef.current) { handled = false; break; }
+                if (!faded) toggleStep(row, col);
+                break;
+            case 'ContextMenu':
+                if (!faded) openFillMenu(cell, row, col);
+                break;
+            case 'F10':
+                if (e.shiftKey && !faded) openFillMenu(cell, row, col);
+                else if (!e.shiftKey) handled = false;
+                break;
+            default: handled = false;
+        }
+        if (handled) {
+            // Stop bubbling so Space doesn't reach App's global play shortcut and
+            // arrows don't scroll the page.
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    }, [menuState.isOpen, moveFocus, openFillMenu, pendingDelete, rowCount, stepsPerMeasure, stepCount, toggleStep]);
+
+    // Announce the active fill option for screen readers while a keyboard menu
+    // is open (focus stays on the pad, so the menu isn't read automatically).
+    const fillAnnouncement = (menuState.isOpen && menuState.source === 'keyboard' && menuState.activeOption)
+        ? `${menuState.activeOption} fill`
+        : '';
+
+    // Focus-into-view: after a keyboard move, focus the target pad. If it's
+    // outside the rendered window, scroll it in first and bail — the scroll
+    // listener updates visibleRange, which re-runs this effect with the pad now
+    // in the DOM.
+    useLayoutEffect(() => {
+        if (!navFocusRef.current) return;
+        const container = scrollContainerRef.current;
+        if (!container) return;
+        if (focusCol < visibleRange.start || focusCol >= visibleRange.end) {
+            const { scrollLeft, containerWidth, gridOriginOffset } = geometryRef.current;
+            const target = scrollTargetForStep(focusCol, scrollLeft, containerWidth, gridOriginOffset, grouping, zoom);
+            if (target !== null) {
+                container.scrollTo({ left: target, behavior: 'auto' });
+                return;
+            }
+        }
+        const el = container.querySelector(`[data-row="${focusRow}"][data-col="${focusCol}"]`);
+        if (el) {
+            el.focus();
+            navFocusRef.current = false;
+        }
+    }, [focusRow, focusCol, visibleRange, grouping, zoom]);
+
     return (
         <div className="flex-1 flex flex-col overflow-hidden relative select-none bg-surface-1">
+            <div className="sr-only" role="status" aria-live="polite">{fillAnnouncement}</div>
             {menuState.isOpen && (
                 <ContextMenu
                     ref={menuRef}
@@ -191,6 +327,23 @@ export default function Sequencer({ isPlaying, togglePlay, grid, humanizedMask, 
                         <div className="relative flex">
                             {/* Grid */}
                             <div className="flex flex-col mb-4">
+                                {/* Roving-tabindex grid (APG pattern): focus lives on the
+                                    cells, so the container is intentionally not a tab stop. */}
+                                {/* eslint-disable-next-line jsx-a11y/interactive-supports-focus */}
+                                <div
+                                    role="grid"
+                                    aria-label="Step sequencer"
+                                    aria-rowcount={INSTRUMENTS.length}
+                                    aria-colcount={stepCount}
+                                    className="flex flex-col"
+                                    onKeyDown={handleGridKeyDown}
+                                    onFocus={() => setGridHasFocus(true)}
+                                    onBlur={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setGridHasFocus(false); }}
+                                    // A pointer press inside the grid is pointer intent even when
+                                    // it lands on the already-focused pad (which fires no new focus
+                                    // event) — so Space falls through to play, not toggle.
+                                    onPointerDown={() => { focusViaKeyboardRef.current = false; }}
+                                >
                                 {INSTRUMENTS.map((instrument, rowIdx) => (
                                     <MemoizedInstrumentRow
                                         key={instrument}
@@ -206,9 +359,12 @@ export default function Sequencer({ isPlaying, togglePlay, grid, humanizedMask, 
                                         setMenuState={setMenuState}
                                         pendingDelete={pendingDelete}
                                         zoom={zoom}
-                                        visibleRange={visibleRange}
+                                        visibleRange={renderRange}
+                                        focusedCol={focusRow === rowIdx ? focusCol : -1}
+                                        onFocusCell={handleFocusCell}
                                     />
                                 ))}
+                                </div>
 
                                 {/* Delete Measure Footer */}
                                 <MeasureControls

--- a/src/components/Sequencer.test.jsx
+++ b/src/components/Sequencer.test.jsx
@@ -22,10 +22,23 @@ vi.mock('./SequencerHeader', () => ({
 }));
 
 vi.mock('./InstrumentRow', () => ({
-    MemoizedInstrumentRow: ({ instrument, rowIdx, toggleStep }) => (
-        <div data-testid={`mock-instrument-row`}>
+    MemoizedInstrumentRow: ({ instrument, rowIdx, toggleStep, focusedCol, onFocusCell }) => (
+        <div data-testid={`mock-instrument-row`} role="row">
             {instrument}
             <button onClick={() => toggleStep(rowIdx, 0)}>Toggle</button>
+            {[0, 1, 2].map((c) => (
+                <div
+                    key={c}
+                    data-testid={`cell-${rowIdx}-${c}`}
+                    data-row={rowIdx}
+                    data-col={c}
+                    role="checkbox"
+                    aria-checked={false}
+                    aria-label={`${instrument} ${c}`}
+                    tabIndex={focusedCol === c ? 0 : -1}
+                    onFocus={() => onFocusCell?.(rowIdx, c)}
+                />
+            ))}
         </div>
     )
 }));
@@ -51,10 +64,11 @@ vi.mock('../hooks/useAutoScroll', () => ({
     useAutoScroll: vi.fn()
 }));
 
+const { mockSetMenuState } = vi.hoisted(() => ({ mockSetMenuState: vi.fn() }));
 vi.mock('../hooks/useSequencerSelection', () => ({
     useSequencerSelection: () => ({
-        menuState: { isOpen: false },
-        setMenuState: vi.fn(),
+        menuState: { isOpen: false, source: 'pointer' },
+        setMenuState: mockSetMenuState,
         menuRef: { current: null }
     })
 }));
@@ -76,6 +90,9 @@ global.ResizeObserver = class ResizeObserver {
 Element.prototype.getBoundingClientRect = vi.fn(() => ({
     left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600
 }));
+
+// jsdom doesn't implement scrollTo; the focus-into-view effect may call it.
+Element.prototype.scrollTo = Element.prototype.scrollTo || vi.fn();
 
 describe('Sequencer', () => {
     const defaultProps = {
@@ -183,6 +200,111 @@ describe('Sequencer', () => {
         // the arrow-right icon should now be present in the DOM
         const offRightIcon = container.querySelector('use[href="#icon-arrow-right"]');
         expect(offRightIcon).toBeInTheDocument();
+    });
+
+    it('exposes the grid with roles and one roving tab stop at (0,0)', () => {
+        render(<Sequencer {...defaultProps} />);
+        expect(screen.getByRole('grid')).toBeInTheDocument();
+        expect(screen.getByTestId('cell-0-0')).toHaveAttribute('tabindex', '0');
+        expect(screen.getByTestId('cell-0-1')).toHaveAttribute('tabindex', '-1');
+        expect(screen.getByTestId('cell-1-0')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('moves the roving tab stop with arrow keys', () => {
+        render(<Sequencer {...defaultProps} />);
+        fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: 'ArrowRight' });
+        expect(screen.getByTestId('cell-0-1')).toHaveAttribute('tabindex', '0');
+        expect(screen.getByTestId('cell-0-0')).toHaveAttribute('tabindex', '-1');
+
+        fireEvent.keyDown(screen.getByTestId('cell-0-1'), { key: 'ArrowDown' });
+        expect(screen.getByTestId('cell-1-1')).toHaveAttribute('tabindex', '0');
+    });
+
+    it('toggles the focused step on Enter without bubbling to global shortcuts', () => {
+        const windowKeySpy = vi.fn();
+        window.addEventListener('keydown', windowKeySpy);
+        try {
+            render(<Sequencer {...defaultProps} />);
+            fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: 'Enter' });
+            expect(defaultProps.toggleStep).toHaveBeenCalledWith(0, 0);
+            expect(windowKeySpy).not.toHaveBeenCalled(); // consumed, never reaches App
+        } finally {
+            window.removeEventListener('keydown', windowKeySpy);
+        }
+    });
+
+    it('toggles on Space when the pad was focused via keyboard (consumes the key)', () => {
+        const windowKeySpy = vi.fn();
+        window.addEventListener('keydown', windowKeySpy);
+        try {
+            render(<Sequencer {...defaultProps} />);
+            fireEvent.mouseDown(document);                      // start in pointer modality...
+            fireEvent.keyDown(document, { key: 'Tab' });        // ...then keyboard flips it back
+            fireEvent.focus(screen.getByTestId('cell-0-0'));    // focus arrives via keyboard
+            windowKeySpy.mockClear();
+            fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: ' ' });
+            expect(defaultProps.toggleStep).toHaveBeenCalledWith(0, 0);
+            expect(windowKeySpy).not.toHaveBeenCalled(); // consumed, App's play never fires
+        } finally {
+            window.removeEventListener('keydown', windowKeySpy);
+        }
+    });
+
+    it('lets Space bubble to global play when the pad was focused via pointer', () => {
+        const windowKeySpy = vi.fn();
+        window.addEventListener('keydown', windowKeySpy);
+        try {
+            render(<Sequencer {...defaultProps} />);
+            fireEvent.mouseDown(document);                      // input modality -> pointer
+            fireEvent.focus(screen.getByTestId('cell-0-0'));    // focus arrives via pointer
+            windowKeySpy.mockClear();
+            fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: ' ' });
+            expect(defaultProps.toggleStep).not.toHaveBeenCalled();
+            expect(windowKeySpy).toHaveBeenCalled(); // bubbles → App's Space=play would fire
+        } finally {
+            window.removeEventListener('keydown', windowKeySpy);
+        }
+    });
+
+    it('reverts to play when a keyboard-focused pad is then clicked (no refocus fires)', () => {
+        const windowKeySpy = vi.fn();
+        window.addEventListener('keydown', windowKeySpy);
+        try {
+            render(<Sequencer {...defaultProps} />);
+            fireEvent.keyDown(document, { key: 'Tab' });
+            fireEvent.focus(screen.getByTestId('cell-0-0'));     // keyboard focus -> Space would toggle
+            fireEvent.pointerDown(screen.getByTestId('cell-0-0')); // pointer intent on the focused pad
+            windowKeySpy.mockClear();
+            fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: ' ' });
+            expect(defaultProps.toggleStep).not.toHaveBeenCalled();
+            expect(windowKeySpy).toHaveBeenCalled(); // bubbles → play
+        } finally {
+            window.removeEventListener('keydown', windowKeySpy);
+        }
+    });
+
+    it('opens the bulk-fill menu from the keyboard (ContextMenu / Shift+F10)', () => {
+        render(<Sequencer {...defaultProps} />);
+        fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: 'ContextMenu' });
+        expect(mockSetMenuState).toHaveBeenCalledWith(expect.objectContaining({
+            isOpen: true, source: 'keyboard', row: 0, col: 0, activeOption: 'repeat'
+        }));
+
+        mockSetMenuState.mockClear();
+        fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: 'F10', shiftKey: true });
+        expect(mockSetMenuState).toHaveBeenCalledWith(expect.objectContaining({
+            isOpen: true, source: 'keyboard'
+        }));
+    });
+
+    it('does not toggle a step in a measure pending deletion (faded)', () => {
+        render(<Sequencer {...defaultProps} />);
+        fireEvent.click(screen.getByText('Delete 0')); // setPendingDelete(0) -> measure 0 faded
+        fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: ' ' });
+        expect(defaultProps.toggleStep).not.toHaveBeenCalled();
+        // ...but the menu also stays closed for a faded cell
+        fireEvent.keyDown(screen.getByTestId('cell-0-0'), { key: 'ContextMenu' });
+        expect(mockSetMenuState).not.toHaveBeenCalled();
     });
 
     it('handles wheel event for manual scroll', () => {

--- a/src/data/sequencerConfig.js
+++ b/src/data/sequencerConfig.js
@@ -38,6 +38,10 @@ export const ZOOM_CONFIG = {
     }
 };
 
+// Bulk-fill modes, in menu order. Single source of truth shared by the menu
+// render (ContextMenu) and the keyboard cycling (useSequencerSelection).
+export const FILL_MODES = ['repeat', 'alternate', 'clear'];
+
 export const INSTRUMENT_ICONS = {
     "Kick": "kick",
     "Snare": "snare",

--- a/src/hooks/useInputModality.js
+++ b/src/hooks/useInputModality.js
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Tracks whether the user's most recent interaction was keyboard- or pointer-
+ * driven — the same heuristic the platform uses for `:focus-visible`. Returns a
+ * ref whose `.current` is `'keyboard' | 'pointer'`.
+ *
+ * Read it at focus time to tell how a control was focused (Tab/arrow vs click),
+ * e.g. to decide whether Space should activate the focused control or fall
+ * through to a global shortcut.
+ */
+export function useInputModality() {
+    const modalityRef = useRef('keyboard');
+
+    useEffect(() => {
+        const setKeyboard = () => { modalityRef.current = 'keyboard'; };
+        const setPointer = () => { modalityRef.current = 'pointer'; };
+
+        // Capture phase so the modality is set before focus handlers read it.
+        document.addEventListener('keydown', setKeyboard, true);
+        document.addEventListener('pointerdown', setPointer, true);
+        document.addEventListener('mousedown', setPointer, true);
+        document.addEventListener('touchstart', setPointer, true);
+
+        return () => {
+            document.removeEventListener('keydown', setKeyboard, true);
+            document.removeEventListener('pointerdown', setPointer, true);
+            document.removeEventListener('mousedown', setPointer, true);
+            document.removeEventListener('touchstart', setPointer, true);
+        };
+    }, []);
+
+    return modalityRef;
+}

--- a/src/hooks/useInputModality.test.js
+++ b/src/hooks/useInputModality.test.js
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useInputModality } from './useInputModality';
+
+describe('useInputModality', () => {
+    it('defaults to keyboard', () => {
+        const { result } = renderHook(() => useInputModality());
+        expect(result.current.current).toBe('keyboard');
+    });
+
+    it('switches to pointer on mousedown / pointerdown / touchstart', () => {
+        const { result } = renderHook(() => useInputModality());
+        document.dispatchEvent(new MouseEvent('mousedown'));
+        expect(result.current.current).toBe('pointer');
+    });
+
+    it('switches back to keyboard on keydown', () => {
+        const { result } = renderHook(() => useInputModality());
+        document.dispatchEvent(new MouseEvent('mousedown'));
+        expect(result.current.current).toBe('pointer');
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+        expect(result.current.current).toBe('keyboard');
+    });
+
+    it('stops tracking after unmount', () => {
+        const { result, unmount } = renderHook(() => useInputModality());
+        const ref = result.current;
+        unmount();
+        document.dispatchEvent(new MouseEvent('mousedown'));
+        expect(ref.current).toBe('keyboard'); // listener removed, ref unchanged
+    });
+});

--- a/src/hooks/useSequencerSelection.js
+++ b/src/hooks/useSequencerSelection.js
@@ -3,15 +3,17 @@
 // SPDX-License-Identifier: ISC
 
 import { useState, useRef, useEffect } from 'react';
+import { FILL_MODES } from '../data/sequencerConfig';
 
 export function useSequencerSelection({ onBulkUpdate }) {
-    const [menuState, setMenuState] = useState({ 
-        isOpen: false, 
-        x: 0, 
-        y: 0, 
-        row: null, 
-        col: null, 
-        activeOption: null 
+    const [menuState, setMenuState] = useState({
+        isOpen: false,
+        x: 0,
+        y: 0,
+        row: null,
+        col: null,
+        activeOption: null,
+        source: 'pointer' // 'pointer' (long-press drag) | 'keyboard'
     });
     
     const menuRef = useRef(null);
@@ -26,8 +28,47 @@ export function useSequencerSelection({ onBulkUpdate }) {
         bulkUpdateStepRef.current = onBulkUpdate;
     }, [onBulkUpdate]);
 
+    // Keyboard-opened menu: arrow keys cycle the option, Enter/Space commit,
+    // Escape/Tab cancel. Capture phase + stopImmediatePropagation so the grid's
+    // own keydown handler doesn't also act on these keys. Focus stays on the
+    // originating pad throughout (the menu is a non-focusable overlay).
     useEffect(() => {
-        if (!menuState.isOpen) return;
+        if (!menuState.isOpen || menuState.source !== 'keyboard') return;
+
+        const handleKey = (e) => {
+            const current = menuStateRef.current;
+            const close = () => setMenuState(prev => ({ ...prev, isOpen: false }));
+
+            if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                const idx = Math.max(0, FILL_MODES.indexOf(current.activeOption));
+                const next = e.key === 'ArrowDown'
+                    ? (idx + 1) % FILL_MODES.length
+                    : (idx - 1 + FILL_MODES.length) % FILL_MODES.length;
+                setMenuState(prev => ({ ...prev, activeOption: FILL_MODES[next] }));
+            } else if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                if (current.activeOption) {
+                    bulkUpdateStepRef.current(current.row, current.col, current.activeOption);
+                }
+                close();
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                close();
+            } else if (e.key === 'Tab') {
+                close(); // let focus move on naturally
+            }
+        };
+
+        window.addEventListener('keydown', handleKey, true);
+        return () => window.removeEventListener('keydown', handleKey, true);
+    }, [menuState.isOpen, menuState.source]);
+
+    useEffect(() => {
+        if (!menuState.isOpen || menuState.source === 'keyboard') return;
 
         const handleMove = (e) => {
             e.stopImmediatePropagation();
@@ -77,7 +118,7 @@ export function useSequencerSelection({ onBulkUpdate }) {
             window.removeEventListener('touchend', handleEnd);
             window.removeEventListener('touchcancel', handleCancel);
         };
-    }, [menuState.isOpen]);
+    }, [menuState.isOpen, menuState.source]);
 
     return {
         menuState,

--- a/src/hooks/useSequencerSelection.test.js
+++ b/src/hooks/useSequencerSelection.test.js
@@ -27,7 +27,8 @@ describe('useSequencerSelection', () => {
             y: 0,
             row: null,
             col: null,
-            activeOption: null
+            activeOption: null,
+            source: 'pointer'
         });
     });
 
@@ -202,5 +203,55 @@ describe('useSequencerSelection', () => {
         });
 
         expect(result.current.menuState.isOpen).toBe(false);
+    });
+
+    describe('keyboard-opened menu (source: keyboard)', () => {
+        const openKeyboard = (result, opts = {}) => act(() => {
+            result.current.setMenuState({
+                isOpen: true, x: 0, y: 0, row: 0, col: 0,
+                activeOption: 'repeat', source: 'keyboard', ...opts
+            });
+        });
+
+        it('cycles the active option with arrow keys (wrapping both ways)', () => {
+            const { result } = renderHook(() => useSequencerSelection({ onBulkUpdate: vi.fn() }));
+            openKeyboard(result);
+
+            act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })));
+            expect(result.current.menuState.activeOption).toBe('alternate');
+            act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })));
+            expect(result.current.menuState.activeOption).toBe('clear');
+            act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })));
+            expect(result.current.menuState.activeOption).toBe('repeat'); // wraps forward
+            act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' })));
+            expect(result.current.menuState.activeOption).toBe('clear'); // wraps backward
+        });
+
+        it('commits the active option and closes on Enter', () => {
+            const onBulkUpdate = vi.fn();
+            const { result } = renderHook(() => useSequencerSelection({ onBulkUpdate }));
+            openKeyboard(result, { row: 1, col: 2, activeOption: 'alternate' });
+
+            act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })));
+            expect(onBulkUpdate).toHaveBeenCalledWith(1, 2, 'alternate');
+            expect(result.current.menuState.isOpen).toBe(false);
+        });
+
+        it('closes without committing on Escape', () => {
+            const onBulkUpdate = vi.fn();
+            const { result } = renderHook(() => useSequencerSelection({ onBulkUpdate }));
+            openKeyboard(result);
+
+            act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+            expect(onBulkUpdate).not.toHaveBeenCalled();
+            expect(result.current.menuState.isOpen).toBe(false);
+        });
+
+        it('attaches keydown navigation, not pointer drag listeners', () => {
+            const { result } = renderHook(() => useSequencerSelection({ onBulkUpdate: vi.fn() }));
+            openKeyboard(result);
+            expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
+            expect(addEventListenerSpy).not.toHaveBeenCalledWith('mousemove', expect.any(Function), { passive: false });
+        });
     });
 });

--- a/src/utils/sequencerGeometry.js
+++ b/src/utils/sequencerGeometry.js
@@ -54,6 +54,18 @@ export function measureWidth(stepsPerMeasure, grouping, zoom) {
     return stepsPerMeasure * (config.cellWidth + config.gap) + Math.max(0, groupsInMeasure - 1) * config.groupGap;
 }
 
+// Scroll offset needed to bring `step` into view, centered, or null if it is
+// already within the viewport. Mirrors the visible-range math in Sequencer
+// (content-x compared against [scrollLeft - origin, scrollLeft + width - origin])
+// and the playhead's centering. Used for keyboard focus-into-view.
+export function scrollTargetForStep(step, scrollLeft, containerWidth, gridOriginOffset, grouping, zoom) {
+    const x = stepToX(step, grouping, zoom);
+    const viewLeft = scrollLeft - gridOriginOffset;
+    const viewRight = scrollLeft + containerWidth - gridOriginOffset;
+    if (x >= viewLeft && x <= viewRight) return null; // already visible
+    return Math.max(0, Math.round(x + gridOriginOffset - containerWidth / 2));
+}
+
 export function xToStep(x, stepCount, grouping, zoom) {
     const safeStepCount = Math.max(1, stepCount || 1);
     const maxStep = safeStepCount - 1;

--- a/src/utils/sequencerGeometry.test.js
+++ b/src/utils/sequencerGeometry.test.js
@@ -14,6 +14,7 @@ import {
     getGridOriginOffsetPx,
     isMobileViewport,
     measureWidth,
+    scrollTargetForStep,
     sequenceWidth,
     stepToX,
     xToStep,
@@ -80,5 +81,24 @@ describe('sequencerGeometry', () => {
 
     it('falls back to default zoom config for unknown zoom levels', () => {
         expect(stepToX(4, 4, 999)).toBe(stepToX(4, 4, 1));
+    });
+
+    describe('scrollTargetForStep', () => {
+        // origin 48, viewport 400 wide, grouping 4, zoom 1
+        it('returns null when the step is already within the viewport', () => {
+            expect(scrollTargetForStep(0, 0, 400, 48, 4, 1)).toBeNull();
+            expect(scrollTargetForStep(5, 0, 400, 48, 4, 1)).toBeNull(); // x=192 within [-48,352]
+        });
+
+        it('centers a step that is off the right edge', () => {
+            // step 20 -> x = 20*36 + 5*12 = 780, beyond viewRight (352)
+            // target = round(780 + 48 - 200) = 628
+            expect(scrollTargetForStep(20, 0, 400, 48, 4, 1)).toBe(628);
+        });
+
+        it('clamps to zero when centering a step near the start', () => {
+            // scrolled to 600; step 0 (x=0) is off the left edge; centered target is negative -> 0
+            expect(scrollTargetForStep(0, 600, 400, 48, 4, 1)).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
Make the step grid, previously pointer-only, a fully keyboard-operable WAI-ARIA grid that stays out of the way of the global shortcuts.

- Semantics: grid/row/rowheader/gridcell + checkbox cells (aria-checked, aria-label) with aria-rowindex/colindex/colcount carrying true positions despite windowed rendering; lane/window wrappers are presentational so cells hoist to the row.
- Navigation: one roving tab stop with arrow/Home/End; a focus-into-view effect scrolls an off-window pad in, then focuses it; the focused column is force- rendered while the grid has focus so a scroll can't drop focus to <body>.
- Editing: Enter toggles; ContextMenu/Shift+F10 opens the bulk-fill menu, driven by arrow/Enter/Escape (menuState gains a pointer|keyboard source); a shared FILL_MODES constant keeps menu and keyboard cycling in sync. Toggles/menu are suppressed on a measure pending deletion.
- "Smart Space": Space toggles a pad only when it was focused via keyboard (a :focus-visible-style modality tracker, useInputModality); a pointer-focused pad lets Space fall through to the global play/pause shortcut. Screen-reader users (always keyboard) keep the checkbox Space-toggle; mouse users keep Space=play.
- Announcements: visually-hidden aria-live regions for transport state and the active fill option.
- Guard: add eslint-plugin-jsx-a11y (via overrides; eslint 10 isn't in its peer range yet). ARIA-correctness rules are errors; two static-interaction rules are warnings for pre-existing click-divs.